### PR TITLE
fix bug missing email body and upgrade version MailKit lib

### DIFF
--- a/src/Smartstore/Net/Mail/DefaultMailService.cs
+++ b/src/Smartstore/Net/Mail/DefaultMailService.cs
@@ -167,6 +167,8 @@ namespace Smartstore.Net.Mail
                 multipart.Add(BuildMimePart(attachment));
             }
 
+            msg.Body = multipart;
+
             // Headers
             foreach (var kvp in original.Headers)
             {

--- a/src/Smartstore/Smartstore.csproj
+++ b/src/Smartstore/Smartstore.csproj
@@ -32,7 +32,7 @@
         <PackageReference Include="CronExpressionDescriptor" Version="2.16.0" />
         <PackageReference Include="HtmlSanitizer" Version="7.1.475" />
         <PackageReference Include="Humanizer" Version="2.13.14" />
-        <PackageReference Include="MailKit" Version="3.1.0" />
+        <PackageReference Include="MailKit" Version="3.3.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.4" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.4" />
         <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />


### PR DESCRIPTION
- fix bug missing email body when send
- MailKit 3.1.0 display wrong message when get error "operation timed out after 1000 milliseconds"