### PR TITLE
fix bug Exception currency is null (when creating new Currency)

### DIFF
--- a/src/Smartstore.Web/Areas/Admin/Controllers/CurrencyController.cs
+++ b/src/Smartstore.Web/Areas/Admin/Controllers/CurrencyController.cs
@@ -413,7 +413,7 @@ namespace Smartstore.Admin.Controllers
                 try
                 {
                     var currency = _db.Currencies.FindById(currencyId, false);
-                    var clone = currency.Clone();
+                    var clone = currency?.Clone() ?? new Currency();
                     clone.Id = 0;
                     clone.CustomFormatting = customFormat;
 


### PR DESCRIPTION
An error occurs when changing the currency format in the form to create a new currency. When not saved, currency = null so it will not be possible to use the clone() method