### PR TITLE
Fix: hovering over product image

### DIFF
--- a/src/Smartstore.Web/Views/Shared/Partials/MediaGallery.cshtml
+++ b/src/Smartstore.Web/Views/Shared/Partials/MediaGallery.cshtml
@@ -81,7 +81,7 @@
                                      data-zoom-width="@file.Size.Width"
                                      data-zoom-height="@file.Size.Height"
                                      alt="@file.Alt"
-                                     title="@file.TitleAttribute"
+                                     
                                      itemprop="image" />
                             }
                             else


### PR DESCRIPTION
When hovering on the product image the title will popup and glitch out the zoomed image.
Platform: Desktop