### PR TITLE
Switched to using AsyncKeyedLock library in order to fix concurrency issue with AsyncLock

### DIFF
--- a/src/Smartstore/Caching/HybridCacheManager.cs
+++ b/src/Smartstore/Caching/HybridCacheManager.cs
@@ -257,7 +257,7 @@ namespace Smartstore.Caching
 
             // Get the (semaphore) locker specific to this key from LAST store.
             // Atomic operation must be outer locked
-            await using (await GetLock(key).AcquireAsync(TimeSpan.FromSeconds(5)))
+            using (await GetLock(key).AcquireAsync(TimeSpan.FromSeconds(5)))
             {
                 // Check again
                 entry = (await GetInternal(key, independent, true)).Entry;

--- a/src/Smartstore/Caching/MemoryCacheStore.cs
+++ b/src/Smartstore/Caching/MemoryCacheStore.cs
@@ -293,10 +293,10 @@ namespace Smartstore.Caching
         public IDistributedLock GetLock(string key)
             => new DistributedSemaphoreLock("memcache:" + key);
 
-        public virtual ILockHandle AcquireKeyLock(string key, CancellationToken cancelToken = default)
+        public virtual IDisposable AcquireKeyLock(string key, CancellationToken cancelToken = default)
             => AsyncLock.Keyed("memcache:" + key, TimeSpan.FromSeconds(5), cancelToken);
 
-        public virtual Task<ILockHandle> AcquireAsyncKeyLock(string key, CancellationToken cancelToken = default)
+        public virtual ValueTask<IDisposable> AcquireAsyncKeyLock(string key, CancellationToken cancelToken = default)
             => AsyncLock.KeyedAsync("memcache:" + key, TimeSpan.FromSeconds(5), cancelToken);
 
         public virtual void Clear()

--- a/src/Smartstore/Smartstore.csproj
+++ b/src/Smartstore/Smartstore.csproj
@@ -27,6 +27,7 @@
     <ItemGroup>
         <PackageReference Include="AngleSharp" Version="0.17.1" />
         <PackageReference Include="AngleSharp.Css" Version="0.16.4" />
+        <PackageReference Include="AsyncKeyedLock" Version="5.1.0" />
         <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
         <PackageReference Include="Barcoder" Version="1.1.1" />
         <PackageReference Include="CronExpressionDescriptor" Version="2.18.0" />

--- a/src/Smartstore/Threading/DistributedLock/DistributedSemaphoreLockProvider.cs
+++ b/src/Smartstore/Threading/DistributedLock/DistributedSemaphoreLockProvider.cs
@@ -28,12 +28,12 @@
             return Task.FromResult(AsyncLock.IsLockHeld(Key));
         }
 
-        public ILockHandle Acquire(TimeSpan timeout, CancellationToken cancelToken = default)
+        public IDisposable Acquire(TimeSpan timeout, CancellationToken cancelToken = default)
         {
             return AsyncLock.Keyed(Key, timeout, cancelToken);
         }
 
-        public Task<ILockHandle> AcquireAsync(TimeSpan timeout, CancellationToken cancelToken = default)
+        public ValueTask<IDisposable> AcquireAsync(TimeSpan timeout, CancellationToken cancelToken = default)
         {
             return AsyncLock.KeyedAsync(Key, timeout, cancelToken);
         }

--- a/src/Smartstore/Threading/DistributedLock/IDistributedLock.cs
+++ b/src/Smartstore/Threading/DistributedLock/IDistributedLock.cs
@@ -34,8 +34,8 @@
         /// </summary>
         /// <param name="timeout">How long to wait before giving up on the acquisition attempt.</param>
         /// <param name="cancelToken">Specifies a token by which the wait can be canceled.</param>
-        /// <returns>An <see cref="ILockHandle"/> which can be used to release the lock.</returns>
-        ILockHandle Acquire(TimeSpan timeout, CancellationToken cancelToken = default);
+        /// <returns>An <see cref="IDisposable"/> which can be used to release the lock.</returns>
+        IDisposable Acquire(TimeSpan timeout, CancellationToken cancelToken = default);
 
         /// <summary>
         /// Acquires the lock asynchronously, failing with <see cref="TimeoutException"/> if the attempt times out. Usage: 
@@ -49,7 +49,7 @@
         /// </summary>
         /// <param name="timeout">How long to wait before giving up on the acquisition attempt.</param>
         /// <param name="cancelToken">Specifies a token by which the wait can be canceled.</param>
-        /// <returns>An <see cref="ILockHandle"/> which can be used to release the lock.</returns>
-        Task<ILockHandle> AcquireAsync(TimeSpan timeout, CancellationToken cancelToken = default);
+        /// <returns>An <see cref="IDisposable"/> which can be used to release the lock.</returns>
+        ValueTask<IDisposable> AcquireAsync(TimeSpan timeout, CancellationToken cancelToken = default);
     }
 }

--- a/src/Smartstore/Threading/DistributedLock/IDistributedLockExtensions.cs
+++ b/src/Smartstore/Threading/DistributedLock/IDistributedLockExtensions.cs
@@ -15,7 +15,7 @@
         ///     // releases the lock
         /// </code>
         /// </summary>
-        public static ILockHandle Acquire(this IDistributedLock @lock, CancellationToken cancelToken = default)
+        public static IDisposable Acquire(this IDistributedLock @lock, CancellationToken cancelToken = default)
         {
             return @lock.Acquire(Timeout.InfiniteTimeSpan, cancelToken);
         }
@@ -34,7 +34,7 @@
         ///     }
         /// </code>
         /// </summary>
-        public static bool TryAcquire(this IDistributedLock @lock, out ILockHandle lockHandle)
+        public static bool TryAcquire(this IDistributedLock @lock, out IDisposable lockHandle)
         {
             return TryAcquire(@lock, NoTimeout, out lockHandle);
         }
@@ -50,9 +50,9 @@
         /// </code>
         /// </summary>
         /// <param name="timeout">How long to wait before giving up on the acquisition attempt.</param>
-        /// <param name="lockHandle">An <see cref="ILockHandle"/> which can be used to release the lock.</param>
+        /// <param name="lockHandle">An <see cref="IDisposable"/> which can be used to release the lock.</param>
         /// <returns><c>true</c> if the lock was acquired, <c>false</c> otherwise.</returns>
-        public static bool TryAcquire(this IDistributedLock @lock, TimeSpan timeout, out ILockHandle lockHandle)
+        public static bool TryAcquire(this IDistributedLock @lock, TimeSpan timeout, out IDisposable lockHandle)
         {
             lockHandle = null;
 
@@ -79,7 +79,7 @@
         ///     // releases the lock
         /// </code>
         /// </summary>
-        public static Task<ILockHandle> AcquireAsync(this IDistributedLock @lock, CancellationToken cancelToken = default)
+        public static ValueTask<IDisposable> AcquireAsync(this IDistributedLock @lock, CancellationToken cancelToken = default)
         {
             return @lock.AcquireAsync(Timeout.InfiniteTimeSpan, cancelToken);
         }
@@ -98,7 +98,7 @@
         ///     }
         /// </code>
         /// </summary>
-        public static Task<AsyncOut<ILockHandle>> TryAcquireAsync(this IDistributedLock @lock, CancellationToken cancelToken = default)
+        public static Task<AsyncOut<IDisposable>> TryAcquireAsync(this IDistributedLock @lock, CancellationToken cancelToken = default)
         {
             return TryAcquireAsync(@lock, NoTimeout, cancelToken);
         }
@@ -115,16 +115,16 @@
         /// </summary>
         /// <param name="timeout">How long to wait before giving up on the acquisition attempt.</param>
         /// <param name="cancelToken">Specifies a token by which the wait can be canceled.</param>
-        public static async Task<AsyncOut<ILockHandle>> TryAcquireAsync(this IDistributedLock @lock, TimeSpan timeout, CancellationToken cancelToken = default)
+        public static async Task<AsyncOut<IDisposable>> TryAcquireAsync(this IDistributedLock @lock, TimeSpan timeout, CancellationToken cancelToken = default)
         {
             try
             {
                 var lockHandle = await @lock.AcquireAsync(timeout, cancelToken);
-                return new AsyncOut<ILockHandle>(true, lockHandle);
+                return new AsyncOut<IDisposable>(true, lockHandle);
             }
             catch
             {
-                return AsyncOut<ILockHandle>.Empty;
+                return AsyncOut<IDisposable>.Empty;
             }
         }
     }


### PR DESCRIPTION
Currently, AsyncLock has an issue. Between the time the count is decremented and the time it tries to remove the key from the dictionary, another thread may have acquired the key and incremented the count to 1, but suddenly this is removed from the dictionary while it's still being processed, which means that a third thread with the same key will not find it in the dictionary and you can effectively have 2 concurrent threads with the same key.

This PR uses a more performant library which avoids these concurrency issues outlined above.