### PR TITLE
Fix for themes inside modules.

### DIFF
--- a/src/Smartstore/Engine/Modularity/ModuleLoader.cs
+++ b/src/Smartstore/Engine/Modularity/ModuleLoader.cs
@@ -30,7 +30,7 @@ namespace Smartstore.Engine.Modularity
                     // Create symlink only if theme dir does not exist
                     try
                     {
-                        File.CreateSymbolicLink(themeDir.PhysicalPath, descriptor.PhysicalPath);
+                        File.CreateSymbolicLink(themeDir.PhysicalPath, Path.Combine(descriptor.PhysicalPath, "Themes", descriptor.Theme));
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
Until now the created symlink pointed to the module root folder instead of the theme folder itself. Works for linux now, for windows, there still is work to do in the EnumerateDirectories methods, since they don't resolve symlinks. Workaround for devs on windows: create a junction (mklink /J).