### PR TITLE
Adds WebAPI setting to override SSL requirement

### DIFF
--- a/src/Smartstore.Modules/Smartstore.WebApi/Configuration/WebApiSettings.cs
+++ b/src/Smartstore.Modules/Smartstore.WebApi/Configuration/WebApiSettings.cs
@@ -30,6 +30,11 @@ namespace Smartstore.Web.Api
         /// </summary>
         public int MaxExpansionDepth { get; set; } = 8;
 
+        /// <summary>
+        /// Gets or sets the override for SSL encryption requirement.
+        /// </summary>
+        public bool SSLRequirementOverride { get; set; } = false;
+
         #region Batch
 
         /// <summary>

--- a/src/Smartstore.Modules/Smartstore.WebApi/Localization/resources.de-de.xml
+++ b/src/Smartstore.Modules/Smartstore.WebApi/Localization/resources.de-de.xml
@@ -123,4 +123,10 @@
     <LocaleResource Name="MaxBatchReceivedMessageSize.Hint">
         <Value>Legt die maximale Datenmenge (in KB) fest, die aus einer Stapelnachricht gelesen werden soll.</Value>
     </LocaleResource>
+    <LocaleResource Name="SSLRequirementOverride">
+        <Value>Legt fest, ob API-Zugriff ohne SSL möglich sein soll.</Value>
+    </LocaleResource>
+    <LocaleResource Name="SSLRequirementOverride.Hint">
+        <Value>Nur verwenden, wenn z.B. der Shop hinter einem Proxy oder Loadbalancer liegt und SSL-Verschlüsselung anders geregelt ist.</Value>
+    </LocaleResource>
 </Language>

--- a/src/Smartstore.Modules/Smartstore.WebApi/Localization/resources.en-us.xml
+++ b/src/Smartstore.Modules/Smartstore.WebApi/Localization/resources.en-us.xml
@@ -123,4 +123,10 @@
     <LocaleResource Name="MaxBatchReceivedMessageSize.Hint">
         <Value>Specifies the maximum amount of data (in KB) that should be read from a batch message.</Value>
     </LocaleResource>
+    <LocaleResource Name="SSLRequirementOverride">
+        <Value>Determines whether API access should be possible without SSL.</Value>
+    </LocaleResource>
+    <LocaleResource Name="SSLRequirementOverride.Hint">
+        <Value>Only use if, for example, the shop is behind a proxy or load balancer and SSL encryption is done differently</Value>
+    </LocaleResource>
 </Language>

--- a/src/Smartstore.Modules/Smartstore.WebApi/Models/ConfigurationModel.cs
+++ b/src/Smartstore.Modules/Smartstore.WebApi/Models/ConfigurationModel.cs
@@ -28,6 +28,9 @@ namespace Smartstore.Web.Api.Models
         [LocalizedDisplay("*MaxExpansionDepth")]
         public int MaxExpansionDepth { get; set; }
 
+        [LocalizedDisplay("*SSLRequirementOverride")]
+        public bool SSLRequirementOverride { get; set; }
+
         #region Batch
 
         [LocalizedDisplay("*MaxBatchNestingDepth")]

--- a/src/Smartstore.Modules/Smartstore.WebApi/Models/WebApiState.cs
+++ b/src/Smartstore.Modules/Smartstore.WebApi/Models/WebApiState.cs
@@ -26,5 +26,10 @@
         /// Current API version.
         /// </summary>
         public string Version => $"1 {ModuleVersion}";
+
+        /// <summary>
+        /// Is SSL requirement overridden
+        /// </summary>
+        public bool SSLRequirementOverride { get; set; } = false;
     }
 }

--- a/src/Smartstore.Modules/Smartstore.WebApi/Services/Security/BasicAuthenticationHandler.cs
+++ b/src/Smartstore.Modules/Smartstore.WebApi/Services/Security/BasicAuthenticationHandler.cs
@@ -60,7 +60,7 @@ namespace Smartstore.Web.Api.Security
                     return Failure(AccessDeniedReason.ApiDisabled);
                 }
 
-                if (!Request.IsHttps && Options.SslRequired)
+                if (!Request.IsHttps && Options.SslRequired && !state.SSLRequirementOverride)
                 {
                     return Failure(AccessDeniedReason.SslRequired, null, Status421MisdirectedRequest);
                 }

--- a/src/Smartstore.Modules/Smartstore.WebApi/Services/WebApiService.cs
+++ b/src/Smartstore.Modules/Smartstore.WebApi/Services/WebApiService.cs
@@ -101,7 +101,8 @@ namespace Smartstore.Web.Api
                     IsActive = (descriptor?.IsInstalled() ?? false) && settings.IsActive,
                     ModuleVersion = descriptor?.Version?.ToString()?.NullEmpty() ?? "1.0",
                     MaxTop = settings.MaxTop,
-                    MaxExpansionDepth = settings.MaxExpansionDepth
+                    MaxExpansionDepth = settings.MaxExpansionDepth,
+                    SSLRequirementOverride = settings.SSLRequirementOverride
                 };
 
                 return state;

--- a/src/Smartstore.Modules/Smartstore.WebApi/Views/WebApiAdmin/Configure.cshtml
+++ b/src/Smartstore.Modules/Smartstore.WebApi/Views/WebApiAdmin/Configure.cshtml
@@ -115,6 +115,15 @@
                             <span asp-validation-for="MaxBatchReceivedMessageSize"></span>
                         </div>
                     </div>
+                    <div class="adminRow">
+                        <div class="adminTitle">
+                            <smart-label asp-for="SSLRequirementOverride" />
+                        </div>
+                        <div class="adminData form-control-plaintext">
+                            <editor asp-for="SSLRequirementOverride" />
+                            <span asp-validation-for="SSLRequirementOverride"></span>
+                        </div>
+                    </div>
                 </div>
 
             </div>


### PR DESCRIPTION
Resolves #652
Single bool added to WebApiSettings for SSL requirement override for Smartstore shops behind proxies or load balancers.