### PR TITLE
Preliminary mapper callback solution.

### DIFF
--- a/src/Smartstore.Modules/Smartstore.DevTools/MapperCallbackTest.cs
+++ b/src/Smartstore.Modules/Smartstore.DevTools/MapperCallbackTest.cs
@@ -1,0 +1,15 @@
+﻿using Smartstore.ComponentModel;
+using Smartstore.Core.Catalog.Products;
+using Smartstore.Web.Models.Catalog;
+
+namespace Smartstore.DevTools
+{
+    public class MapperCallbackTest : IMapperCallback<Product, ProductDetailsModel>
+    {
+        public Task MapCallback(Product from, ProductDetailsModel to, dynamic parameters = null)
+        {
+            to.CustomProperties["TestId"] = from.Id;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Smartstore.Modules/Smartstore.DevTools/MapperCallbackTest.cs
+++ b/src/Smartstore.Modules/Smartstore.DevTools/MapperCallbackTest.cs
@@ -6,10 +6,9 @@ namespace Smartstore.DevTools
 {
     public class MapperCallbackTest : IMapperCallback<Product, ProductDetailsModel>
     {
-        public Task MapCallback(Product from, ProductDetailsModel to, dynamic parameters = null)
+        public async Task MapCallbackAsync(Product from, ProductDetailsModel to, dynamic parameters = null)
         {
             to.CustomProperties["TestId"] = from.Id;
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Smartstore.Web/Controllers/CatalogHelper.Product.cs
+++ b/src/Smartstore.Web/Controllers/CatalogHelper.Product.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc.Rendering;
 using Smartstore.Collections;
+using Smartstore.ComponentModel;
 using Smartstore.Core.Catalog.Attributes;
 using Smartstore.Core.Catalog.Pricing;
 using Smartstore.Core.Catalog.Products;
@@ -54,6 +55,8 @@ namespace Smartstore.Web.Controllers
 
             // Also purchased products
             await PrepareAlsoPurchasedProductsModelAsync(model, product);
+
+            MapperFactory.MapCallback(product, model);
 
             return model;
         }

--- a/src/Smartstore.Web/Controllers/CatalogHelper.Product.cs
+++ b/src/Smartstore.Web/Controllers/CatalogHelper.Product.cs
@@ -363,6 +363,8 @@ namespace Smartstore.Web.Controllers
 
                 #endregion
 
+                MapperFactory.MapCallback(product, model);
+
                 return model;
             }
         }

--- a/src/Smartstore.Web/Controllers/CatalogHelper.ProductSummary.cs
+++ b/src/Smartstore.Web/Controllers/CatalogHelper.ProductSummary.cs
@@ -1,4 +1,5 @@
 ﻿using Smartstore.Collections;
+using Smartstore.ComponentModel;
 using Smartstore.Core.Catalog.Attributes;
 using Smartstore.Core.Catalog.Discounts;
 using Smartstore.Core.Catalog.Pricing;
@@ -590,6 +591,8 @@ namespace Smartstore.Web.Controllers
                     DisplayOrder = -10
                 });
             }
+
+            MapperFactory.MapCallback(product, item);
 
             model.Items.Add(item);
         }

--- a/src/Smartstore/ComponentModel/IMapperCallback.cs
+++ b/src/Smartstore/ComponentModel/IMapperCallback.cs
@@ -1,0 +1,17 @@
+﻿namespace Smartstore.ComponentModel
+{
+    public interface IMapperCallback<in TFrom, in TTo>
+        where TFrom : class
+        where TTo : class
+    {
+        Task MapCallback(TFrom from, TTo to, dynamic parameters = null);
+    }
+
+    public abstract class MapperCallback<TFrom, TTo> : IMapperCallback<TFrom, TTo>
+        where TFrom : class
+        where TTo : class
+    {
+        public abstract Task MapCallback(TFrom from, TTo to, dynamic parameters = null);
+    }
+
+}

--- a/src/Smartstore/ComponentModel/IMapperCallback.cs
+++ b/src/Smartstore/ComponentModel/IMapperCallback.cs
@@ -4,14 +4,19 @@
         where TFrom : class
         where TTo : class
     {
-        Task MapCallback(TFrom from, TTo to, dynamic parameters = null);
+        Task MapCallbackAsync(TFrom from, TTo to, dynamic parameters = null);
     }
 
     public abstract class MapperCallback<TFrom, TTo> : IMapperCallback<TFrom, TTo>
         where TFrom : class
         where TTo : class
     {
-        public abstract Task MapCallback(TFrom from, TTo to, dynamic parameters = null);
-    }
+        public abstract void MapCallback(TFrom from, TTo to, dynamic parameters = null);
 
+        public virtual Task MapCallbackAsync(TFrom from, TTo to, dynamic parameters = null)
+        {
+            MapCallback(from, to, null);
+            return Task.CompletedTask;
+        }
+    }
 }

--- a/src/Smartstore/ComponentModel/MapperFactory.cs
+++ b/src/Smartstore/ComponentModel/MapperFactory.cs
@@ -176,7 +176,23 @@ namespace Smartstore.ComponentModel
             return new GenericMapper<TFrom, TTo>();
         }
 
-        public static void MapCallback<TFrom, TTo>(TFrom from, TTo to)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static async Task MapCallback<TFrom, TTo>(TFrom from, TTo to, dynamic parameters = null)
+            where TFrom : class
+            where TTo : class
+        {
+            Guard.NotNull(from, nameof(from));
+            Guard.NotNull(to, nameof(to));
+
+            var callbacks = GetMapperCallback<TFrom, TTo>(from, to);
+            foreach (var callback in callbacks)
+            {
+                await callback.MapCallbackAsync(from, to, parameters);
+            }
+        }
+
+
+        public static IEnumerable<IMapperCallback<TFrom, TTo>> GetMapperCallback<TFrom, TTo>(TFrom from, TTo to)
             where TFrom : class
             where TTo : class
         {
@@ -191,7 +207,7 @@ namespace Smartstore.ComponentModel
                     {
                         scope.InjectProperties(instance);
 
-                        instance.MapCallback(from, to);
+                        yield return instance;
                     }
                 }
             }

--- a/src/Smartstore/ComponentModel/MiniMapper.cs
+++ b/src/Smartstore/ComponentModel/MiniMapper.cs
@@ -103,6 +103,8 @@ namespace Smartstore.ComponentModel
                     toProp.SetValue(to, targetValue);
                 }
             }
+
+            MapperFactory.MapCallback(from, to);
         }
 
         private static FastProperty[] GetFastPropertiesFor(Type type)

--- a/src/Smartstore/ComponentModel/MiniMapper.cs
+++ b/src/Smartstore/ComponentModel/MiniMapper.cs
@@ -104,7 +104,7 @@ namespace Smartstore.ComponentModel
                 }
             }
 
-            MapperFactory.MapCallback(from, to).GetAwaiter().GetResult();
+            MapperFactory.MapCallback(from, to).GetAwaiter();
         }
 
         private static FastProperty[] GetFastPropertiesFor(Type type)

--- a/src/Smartstore/ComponentModel/MiniMapper.cs
+++ b/src/Smartstore/ComponentModel/MiniMapper.cs
@@ -104,7 +104,7 @@ namespace Smartstore.ComponentModel
                 }
             }
 
-            MapperFactory.MapCallback(from, to);
+            MapperFactory.MapCallback(from, to).GetAwaiter().GetResult();
         }
 
         private static FastProperty[] GetFastPropertiesFor(Type type)


### PR DESCRIPTION
TODO: find all places where the mapping is not done via MapperFactory/MiniMapper

Referring to http://community.smartstore.com/index.php?/topic/50939-mapperoverride/ this is my preliminary PR for a mapper callback which makes injecting additional data into CustomProperties much easier, making the use of ActionFilters less needed.

Multiple plugins can utilize this, but there is no priority/dependency system.

In some places the mapping is not done via MapperFactory/Minimapper, these classes need to call MapperFactory.MapCallback(from,to) manually.
