### PR TITLE
OrderItemAddedEvent

### DIFF
--- a/src/Smartstore.Core/Checkout/Orders/Events/OrderEvents.cs
+++ b/src/Smartstore.Core/Checkout/Orders/Events/OrderEvents.cs
@@ -1,4 +1,6 @@
-﻿namespace Smartstore.Core.Checkout.Orders.Events
+﻿using Smartstore.Core.Checkout.Cart;
+
+namespace Smartstore.Core.Checkout.Orders.Events
 {
     public class OrderPaidEvent
     {
@@ -28,5 +30,17 @@
         }
 
         public Order Order { get; init; }
+    }
+
+    public class OrderItemAddedEvent
+    {
+        public OrderItemAddedEvent(OrderItem addedItem, OrganizedShoppingCartItem addedCartItem)
+        {
+            AddedItem = Guard.NotNull(addedItem, nameof(addedItem));
+            AddedCartItem = Guard.NotNull(addedCartItem, nameof(addedCartItem));
+        }
+
+        public OrderItem AddedItem { get; init; }
+        public OrganizedShoppingCartItem AddedCartItem { get; init; }
     }
 }

--- a/src/Smartstore.Core/Checkout/Orders/Extensions/OrderEventPublisherExtensions.cs
+++ b/src/Smartstore.Core/Checkout/Orders/Extensions/OrderEventPublisherExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Smartstore.Core.Checkout.Orders;
+﻿using Smartstore.Core.Checkout.Cart;
+using Smartstore.Core.Checkout.Orders;
 using Smartstore.Core.Checkout.Orders.Events;
 using Smartstore.Events;
 
@@ -39,6 +40,21 @@ namespace Smartstore
         {
             return order != null
                 ? eventPublisher.PublishAsync(new OrderUpdatedEvent(order))
+                : Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Publishes the order item added event.
+        /// </summary>
+        /// <param name="eventPublisher">The event publisher.</param>
+        /// <param name="addedItem">The order item instance.</param>
+        /// <param name="addedCartItem">The cart item instance.</param>
+        /// <returns></returns>
+        public static Task PublishOrderItemAddedAsync(this IEventPublisher eventPublisher, OrderItem addedItem,
+            OrganizedShoppingCartItem addedCartItem)
+        {
+            return addedItem != null && addedCartItem != null
+                ? eventPublisher.PublishAsync(new OrderItemAddedEvent(addedItem, addedCartItem))
                 : Task.CompletedTask;
         }
     }

--- a/src/Smartstore.Core/Checkout/Orders/Services/OrderProcessingService.PlaceOrder.cs
+++ b/src/Smartstore.Core/Checkout/Orders/Services/OrderProcessingService.PlaceOrder.cs
@@ -780,6 +780,9 @@ namespace Smartstore.Core.Checkout.Orders
                     }
 
                     ctx.Order.OrderItems.Add(orderItem);
+                    
+                    await _db.SaveChangesAsync();
+                    await _eventPublisher.PublishOrderItemAddedAsync(orderItem, cartItem);
 
                     // Gift cards.
                     if (product.IsGiftCard)


### PR DESCRIPTION
Added a new event, triggered when an item is added to an order. OrderItem is saved beforehand to set the primary key.

A second event for recurring orders might be needed as well.

In reference to http://community.smartstore.com/index.php?/topic/50940-zus%C3%A4tzliche-daten-in-order-%C3%BCbernehmen/