### PR TITLE
Fix for adding media files other than jpg/png/webp like svg through SampleMediaUtility

### DIFF
--- a/src/Smartstore.Core/Content/Media/SampleMediaUtility.cs
+++ b/src/Smartstore.Core/Content/Media/SampleMediaUtility.cs
@@ -85,13 +85,23 @@ namespace Smartstore.Core.Content.Media
                 {
                     mediaFile.Size = (int)stream.Length;
 
-                    var pixelSize = ImageHeader.GetPixelSize(stream);
-                    if (!pixelSize.IsEmpty)
+                    try
                     {
-                        mediaFile.Width = pixelSize.Width;
-                        mediaFile.Height = pixelSize.Height;
+                        var pixelSize = ImageHeader.GetPixelSize(stream);
+                        if (!pixelSize.IsEmpty)
+                        {
+
+                            mediaFile.Width = pixelSize.Width;
+                            mediaFile.Height = pixelSize.Height;
+                        }
+                    }
+                    catch
+                    {
+                        mediaFile.Width = 0;
+                        mediaFile.Height = 0;
                     }
                 }
+                mediaFile.PixelSize = mediaFile.Width * mediaFile.Height;
 
                 _db.MediaFiles.Add(mediaFile);
                 await _db.SaveChangesAsync();


### PR DESCRIPTION
Fixes a exception when adding svg files (and probably other vector images) via the SampleMediaUtility class.
ImageHeader.GetPixelSize throws an exception on vector files.

This also sets the pixel size correctly for normal images which was not set before.