### PR TITLE
Bump AsyncKeyedLock from 6.2.2 to 6.2.4

### DIFF
--- a/src/Smartstore/Smartstore.csproj
+++ b/src/Smartstore/Smartstore.csproj
@@ -27,7 +27,7 @@
     <ItemGroup>
         <PackageReference Include="AngleSharp" Version="0.17.1" />
         <PackageReference Include="AngleSharp.Css" Version="0.17.0" />
-        <PackageReference Include="AsyncKeyedLock" Version="6.2.2" />
+        <PackageReference Include="AsyncKeyedLock" Version="6.2.4" />
         <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
         <PackageReference Include="Barcoder" Version="1.1.1" />
         <PackageReference Include="CronExpressionDescriptor" Version="2.21.0" />


### PR DESCRIPTION
Version bump; no functionality will be affected.