### PR TITLE
[PATCH] Fix Min/Max DateTime bug when app is not on default calendar

### DIFF
--- a/src/Smartstore.Core/Common/JsonConverters/UTCDateTimeConverter.cs
+++ b/src/Smartstore.Core/Common/JsonConverters/UTCDateTimeConverter.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Globalization;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Smartstore.Core.Common.Services;
 
@@ -44,6 +45,17 @@ namespace Smartstore.Core.Common.JsonConverters
                     {
                         value = dtHelper.ConvertToUtcTime(d, dtHelper.CurrentTimeZone);
                     }
+                }
+
+                // In some celandars Min/Max value 0001/01/01 is not supported and they have their own min/max DateTime
+                Calendar calendar = CultureInfo.CurrentCulture.Calendar;
+                if (d == DateTime.MinValue)
+                {
+                    value = calendar.MinSupportedDateTime;
+                }
+                else if (d == DateTime.MaxValue)
+                {
+                    value = calendar.MaxSupportedDateTime;
                 }
             }
 


### PR DESCRIPTION
When store is set to a calture that is not default calcture of app e.g PersianCalture, some reports and view of management panel e.g. currencies and sale chart throws Min/Max unsupported exception.