### PR TITLE
Fix copy attribute issue

### DIFF
--- a/src/Smartstore.Web/Areas/Admin/Views/Product/Grids/_Grid.ProductVariantAttribute.cshtml
+++ b/src/Smartstore.Web/Areas/Admin/Views/Product/Grids/_Grid.ProductVariantAttribute.cshtml
@@ -72,7 +72,7 @@
             </display-template>
             <edit-template>
                 <div v-if="item.row.OptionSets.length > 0" :id="'OptionsSetsContainer' + item.row.Id">
-                    <select class='form-control' :id="'OptionsSetsChoice' + item.row.Id" :data-valcount='item.row.ValueCount'>
+                    <select class='form-control' :id="'OptionsSetsChoice' + item.row.Id" :data-valcount='item.row.NumberOfOptions'>
                         <option v-for="o in item.row.OptionSets" v-bind:value="o.Id">{{ o.Name }}</option>
                     </select>
                 </div>


### PR DESCRIPTION
The 'ValueCount' field has been renamed to 'NumberOfOptions,' but the view has not been updated to reflect this change yet