### PR TITLE
Fixes Request.Path if a X-Forwarded-Prefix header is provided (#933)

### DIFF
--- a/src/Smartstore.Web.Common/WebStarter.cs
+++ b/src/Smartstore.Web.Common/WebStarter.cs
@@ -129,7 +129,21 @@ namespace Smartstore.Web
                 {
                     app.UseForwardedHeaders(MapForwardedHeadersOptions(proxy));
                 }
-                
+
+                // Remove PathBase from Path since UseForwardedHeaders doesn't do it for us
+                app.Use(async (context, next) =>
+                {
+                    if (!string.IsNullOrEmpty(context.Request.PathBase) && context.Request.PathBase != "/")
+                    {
+                        if (context.Request.Path.StartsWithSegments(context.Request.PathBase, out var path))
+                        {
+                            context.Request.Path = path;
+                        }
+                    }
+
+                    await next();
+                });
+
                 // Must come very early.
                 app.UseContextState();
             });


### PR DESCRIPTION
After looking through the ASP.NET Core's `ForwardedHeadersMiddleware` i came to the conclusion that the forwarder middleware doesn't change the Path at all ([see here](https://github.com/dotnet/aspnetcore/blob/7f93c76b39f135c52a387a2eef9a2b72b8119e05/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs#L363-L384)).

This small insertion in `WebStarter.cs` fixes the problem (at least with nginx reverse proxies) and adjusts the Path.
Don't know how IIS will react to it, I don't have a proper test bed for that.