### PR TITLE
Remove unnecessary double write in IFileSystemExtensions

### DIFF
--- a/src/Smartstore/IO/Extensions/IFileSystemExtensions.Write.cs
+++ b/src/Smartstore/IO/Extensions/IFileSystemExtensions.Write.cs
@@ -50,7 +50,6 @@ namespace Smartstore
             var file = async ? await fs.GetFileAsync(subpath) : fs.GetFile(subpath);
 
             using var stream = async ? await file.OpenWriteAsync() : file.OpenWrite();
-            await stream.WriteAsync(contents.AsMemory(0, contents.Length));
 
             if (async)
             {


### PR DESCRIPTION
Removes duplicate calls of ``stream.WriteAsync`` in case of async call (lines 53+57)