### PR TITLE
Add missing await in menu permissions traverse logic

### DIFF
--- a/src/Smartstore.Core/Content/Menus/Services/MenuBase.cs
+++ b/src/Smartstore.Core/Content/Menus/Services/MenuBase.cs
@@ -63,10 +63,10 @@ namespace Smartstore.Core.Content.Menus
             return Task.CompletedTask;
         }
 
-        protected virtual Task DoApplyPermissionsAsync(TreeNode<MenuItem> root)
+        protected virtual async Task DoApplyPermissionsAsync(TreeNode<MenuItem> root)
         {
             // Hide based on permissions
-            root.Traverse(async x =>
+            await root.TraverseAwait(async x =>
             {
                 if (!await MenuItemAccessPermittedAsync(x.Value))
                 {
@@ -86,8 +86,6 @@ namespace Smartstore.Core.Content.Menus
                     }
                 }
             });
-
-            return Task.CompletedTask;
         }
 
         protected abstract string GetCacheKey();


### PR DESCRIPTION
Adds missing await in permissions check. The check uses async lambda which is passed to foreach without await which causes DbContext concurrent access exceptions.