### PR TITLE
Endless redirect loop fix

### DIFF
--- a/src/Smartstore.Core/Platform/Installation/InstallationStarter.cs
+++ b/src/Smartstore.Core/Platform/Installation/InstallationStarter.cs
@@ -47,6 +47,11 @@ namespace Smartstore.Core.Installation
                 {
                     if (!context.Request.Path.StartsWithSegments(InstallPath))
                     {
+                        if (context.Request.Path.StartsWithSegments("/Error"))
+                        {
+                            await next();
+                            return;
+                        }
                         context.Response.Redirect(context.Request.PathBase.Value + InstallPath);
                         return;
                     }


### PR DESCRIPTION
If Smartstore is not yet installed and error happens, InstallationStarter will try to endlessly redirect to installation page. This hotfix adds exception to continue to error page.

This is a fix of https://github.com/smartstore/Smartstore/issues/1097, which was hard to reproduce.