### PR TITLE
Update the Dockerfile to produce a working image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # the source within the container
 # -----------------------------------------------------------
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 # Copy solution and source
 ARG SOLUTION=Smartstore.sln
@@ -26,7 +26,7 @@ RUN dotnet publish Smartstore.Web.csproj -c Release -o /app/release/publish \
 	--no-restore
 
 # Build Docker image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
 EXPOSE 80
 EXPOSE 443
 ENV ASPNETCORE_URLS "http://+:80;https://+:443"
@@ -34,10 +34,8 @@ WORKDIR /app
 COPY --from=build /app/release/publish .
 
 # Install wkhtmltopdf
-RUN apt update &&\
-	apt -y install wget &&\
-	wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_amd64.deb &&\ 
-	apt -y install ./wkhtmltox_0.12.6-1.buster_amd64.deb &&\
-	rm ./wkhtmltox_0.12.6-1.buster_amd64.deb
+RUN apt update && \
+	apt -y install wkhtmltopdf && \
+        apt clean
 
 ENTRYPOINT ["./Smartstore.Web", "--urls", "http://0.0.0.0:80"]


### PR DESCRIPTION
- Update the dotnet version to 8.
- Obtain wkhtmltopdf in a more robust way - the old way didn't work, while the `apt` way works. It pulls along quite a lot of dependencies, is that the reason for the previous hacky way of obtaining it? In any case, I think that something more robust is needed.