### PR TITLE
Bug #1137: Sorting for price does not use discounted prices but the original prices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,5 +238,7 @@ src/Tools/Smartstore.WebApi.Client/Smartstore.WebApi.Client.sln
 
 src/Smartstore.Packager.sln
 Log.txt
-/src/Smartstore.Build/Smartstore.ModuleBuilder/src/Properties
-/src/Smartstore.Web
+/src/Smartstore.Web/smartstore.db
+/src/Smartstore.Web/smartstore.db-shm
+/src/Smartstore.Web/smartstore.db-wal
+/src/Smartstore.Build/Smartstore.ModuleBuilder/src/Properties/launchSettings.json

--- a/.gitignore
+++ b/.gitignore
@@ -238,3 +238,5 @@ src/Tools/Smartstore.WebApi.Client/Smartstore.WebApi.Client.sln
 
 src/Smartstore.Packager.sln
 Log.txt
+/src/Smartstore.Build/Smartstore.ModuleBuilder/src/Properties
+/src/Smartstore.Web

--- a/src/Smartstore.Core/Catalog/Search/CatalogSearchQueryVisitor.cs
+++ b/src/Smartstore.Core/Catalog/Search/CatalogSearchQueryVisitor.cs
@@ -605,7 +605,7 @@ namespace Smartstore.Core.Catalog.Search
             }
             else if (sorting.FieldName == names.Price)
             {
-                query = OrderBy(query, x => x.Price, sorting.Descending);
+                query = OrderBy(query, x => x.SpecialPrice ?? x.Price, sorting.Descending);
             }
 
             return query;

--- a/test/Smartstore.Core.Tests/Catalog/Search/LinqCatalogSearchServiceTests.cs
+++ b/test/Smartstore.Core.Tests/Catalog/Search/LinqCatalogSearchServiceTests.cs
@@ -99,11 +99,32 @@ namespace Smartstore.Core.Tests.Catalog.Search
         }
 
         [Test]
-        public async Task LinqSearch_can_order_by_discounted_price()
+        public async Task LinqSearch_can_order_by_price()
         {
             var products = new List<Product>
             {
                 new SearchProduct(1) { Price=100M, Name="a" },
+                new SearchProduct(2) { Price=200M, Name="b" },
+                new SearchProduct(3) { Price=300M, Name="c"},
+                new SearchProduct(4) { Price=400M, Name="d" }
+            };
+
+            // After sorting by price, order should be d, c, a, b
+
+            var query = new CatalogSearchQuery();
+            query.SortBy(ProductSortingEnum.PriceAsc);
+
+            var result = await SearchAsync(query, products);
+
+            Assert.That(string.Join(",", (await result.GetHitsAsync()).Select(x => x.Name)), Is.EqualTo("a,b,c,d"));
+        }
+
+        [Test]
+        public async Task LinqSearch_can_order_by_discounted_price()
+        {
+            var products = new List<Product>
+            {
+                new SearchProduct(1) { Price=110M, Name="a" },
                 new SearchProduct(2) { Price=200M, Name="b" },
                 new SearchProduct(3) { Price=300M, SpecialPrice = 100M, Name="c"},
                 new SearchProduct(4) { Price=400M, SpecialPrice=90M, Name="d" }

--- a/test/Smartstore.Core.Tests/Catalog/Search/LinqCatalogSearchServiceTests.cs
+++ b/test/Smartstore.Core.Tests/Catalog/Search/LinqCatalogSearchServiceTests.cs
@@ -99,6 +99,27 @@ namespace Smartstore.Core.Tests.Catalog.Search
         }
 
         [Test]
+        public async Task LinqSearch_can_order_by_discounted_price()
+        {
+            var products = new List<Product>
+            {
+                new SearchProduct(1) { Price=100M, Name="a" },
+                new SearchProduct(2) { Price=200M, Name="b" },
+                new SearchProduct(3) { Price=300M, SpecialPrice = 100M, Name="c"},
+                new SearchProduct(4) { Price=400M, SpecialPrice=90M, Name="d" }
+            };
+
+            // After sorting by price, order should be d, c, a, b
+
+            var query = new CatalogSearchQuery();
+            query.SortBy(ProductSortingEnum.PriceAsc);
+
+            var result = await SearchAsync(query, products);
+
+            Assert.That(string.Join(",", (await result.GetHitsAsync()).Select(x => x.Name)), Is.EqualTo("d,c,a,b"));
+        }
+
+        [Test]
         public async Task LinqSearch_can_page_result()
         {
             var products = new List<Product>();


### PR DESCRIPTION
This PR solves [this issue](https://github.com/smartstore/Smartstore/issues/1137). It was requested that the products be sorted by their special price rather than the discounted price.

This PR currently implements this feature. If there is a special price on the product, it will search by that price rather than the original price.