### PR TITLE
Fix null reference in charge refund reason

### DIFF
--- a/src/Smartstore.Modules/Smartstore.Stripe/Controllers/StripeController.cs
+++ b/src/Smartstore.Modules/Smartstore.Stripe/Controllers/StripeController.cs
@@ -504,7 +504,7 @@ namespace Smartstore.StripeElements.Controllers
         {
             if (charge != null)
             {
-                _db.OrderNotes.Add(order, $"Reason for Charge-ID {charge.Id}: {charge.Refunds.FirstOrDefault().Reason} - {charge.Description}", true);
+                _db.OrderNotes.Add(order, $"Reason for Charge-ID {charge.Id}: {charge.Refunds?.FirstOrDefault()?.Reason} - {charge.Description}", true);
             }
         }
     }


### PR DESCRIPTION
Added null-conditional operators to safely access the refund reason when adding order notes.