### PR TITLE
Treat invalid honeypot tokens as bot submissions

### DIFF
--- a/src/Smartstore.Core/Platform/Security/Services/HoneypotProtector.cs
+++ b/src/Smartstore.Core/Platform/Security/Services/HoneypotProtector.cs
@@ -102,6 +102,9 @@ namespace Smartstore.Core.Security
             }
             catch
             {
+                // Any issue while deserializing the token should be considered suspicious
+                // because legitimate requests always carry a valid honeypot payload.
+                isBot = true;
             }
 
             return isBot;


### PR DESCRIPTION
## Summary
- mark malformed honeypot payloads as suspicious bot requests instead of ignoring errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff472e880c832c8a38c6b417ec0f4c