### PR TITLE
Align byte array and regex extensions with extension blocks

### DIFF
--- a/src/Smartstore/Extensions/ByteArrayExtensions.cs
+++ b/src/Smartstore/Extensions/ByteArrayExtensions.cs
@@ -1,10 +1,12 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.IO.Compression;
 using System.Text;
 
-namespace Smartstore
+namespace Smartstore;
+
+public static class ByteArrayExtensions
 {
-    public static class ByteArrayExtensions
+    extension(byte[] value)
     {
         /// <summary>
         /// Converts bytes into hex characters.
@@ -15,7 +17,7 @@ namespace Smartstore
         /// ToHexString(true) produces the same result as <see cref="Convert.ToHexString(byte[])"/>.
         /// </remarks>
         [DebuggerStepThrough]
-        public static string ToHexString(this byte[] value, bool toUpperCase = false, int? maxLength = null)
+        public string ToHexString(bool toUpperCase = false, int? maxLength = null)
         {
             if (value == null || value.Length <= 0)
             {
@@ -26,7 +28,7 @@ namespace Smartstore
             {
                 throw new ArgumentOutOfRangeException(nameof(maxLength), "maxLength must be greater than 1.");
             }
-            
+
             var sb = new StringBuilder(value.Length * 2);
             var format = toUpperCase ? "X2" : "x2";
 
@@ -48,17 +50,17 @@ namespace Smartstore
         /// </summary>
         /// <param name="buffer">Decompressed input</param>
         /// <returns>The compressed result</returns>
-        public static byte[] Zip(this byte[] buffer)
+        public byte[] Zip()
         {
-            if (buffer == null)
+            if (value == null)
             {
-                throw new ArgumentNullException(nameof(buffer));
+                throw new ArgumentNullException(nameof(value));
             }
 
             using (var compressedStream = new MemoryStream())
             using (var zipStream = new GZipStream(compressedStream, CompressionMode.Compress))
             {
-                zipStream.Write(buffer, 0, buffer.Length);
+                zipStream.Write(value, 0, value.Length);
                 zipStream.Close();
                 return compressedStream.ToArray();
             }
@@ -69,17 +71,17 @@ namespace Smartstore
         /// </summary>
         /// <param name="buffer">Decompressed input</param>
         /// <returns>The compressed result</returns>
-        public static async Task<byte[]> ZipAsync(this byte[] buffer)
+        public async Task<byte[]> ZipAsync()
         {
-            if (buffer == null)
+            if (value == null)
             {
-                throw new ArgumentNullException(nameof(buffer));
+                throw new ArgumentNullException(nameof(value));
             }
 
             using (var compressedStream = new MemoryStream())
             using (var zipStream = new GZipStream(compressedStream, CompressionMode.Compress))
             {
-                await zipStream.WriteAsync(buffer);
+                await zipStream.WriteAsync(value);
                 zipStream.Close();
                 return compressedStream.ToArray();
             }
@@ -90,14 +92,14 @@ namespace Smartstore
         /// </summary>
         /// <param name="buffer">Compressed input</param>
         /// <returns>The decompressed result</returns>
-        public static byte[] Unzip(this byte[] buffer)
+        public byte[] Unzip()
         {
-            if (buffer == null)
+            if (value == null)
             {
-                throw new ArgumentNullException(nameof(buffer));
+                throw new ArgumentNullException(nameof(value));
             }
 
-            using (var compressedStream = new MemoryStream(buffer))
+            using (var compressedStream = new MemoryStream(value))
             using (var zipStream = new GZipStream(compressedStream, CompressionMode.Decompress))
             using (var resultStream = new MemoryStream())
             {
@@ -111,14 +113,14 @@ namespace Smartstore
         /// </summary>
         /// <param name="buffer">Compressed input</param>
         /// <returns>The decompressed result</returns>
-        public static async Task<byte[]> UnzipAsync(this byte[] buffer)
+        public async Task<byte[]> UnzipAsync()
         {
-            if (buffer == null)
+            if (value == null)
             {
-                throw new ArgumentNullException(nameof(buffer));
+                throw new ArgumentNullException(nameof(value));
             }
 
-            using (var compressedStream = new MemoryStream(buffer))
+            using (var compressedStream = new MemoryStream(value))
             using (var zipStream = new GZipStream(compressedStream, CompressionMode.Decompress))
             using (var resultStream = new MemoryStream())
             {

--- a/src/Smartstore/Extensions/RegexExtensions.cs
+++ b/src/Smartstore/Extensions/RegexExtensions.cs
@@ -1,22 +1,24 @@
-﻿using System.Text;
+using System.Text;
 using System.Text.RegularExpressions;
 using Smartstore.Utilities;
 
-namespace Smartstore
+namespace Smartstore;
+
+public static class RegexExtensions
 {
-    public static class RegexExtensions
+    extension(Regex regex)
     {
-        public static string ReplaceGroup(this Regex regex, string input, string groupName, string replacement)
+        public string ReplaceGroup(string input, string groupName, string replacement)
         {
-            return ReplaceGroupInternal(regex, input, replacement, m => m.Groups[groupName]);
+            return ReplaceGroupInternal(input, replacement, m => m.Groups[groupName]);
         }
 
-        public static string ReplaceGroup(this Regex regex, string input, int groupNum, string replacement)
+        public string ReplaceGroup(string input, int groupNum, string replacement)
         {
-            return ReplaceGroupInternal(regex, input, replacement, m => m.Groups[groupNum]);
+            return ReplaceGroupInternal(input, replacement, m => m.Groups[groupNum]);
         }
 
-        private static string ReplaceGroupInternal(this Regex regex, string input, string replacement, Func<Match, Group> groupSelector)
+        private string ReplaceGroupInternal(string input, string replacement, Func<Match, Group> groupSelector)
         {
             return regex.Replace(input, match =>
             {
@@ -41,7 +43,7 @@ namespace Smartstore
             });
         }
 
-        public static async Task<string> ReplaceAsync(this Regex regex, string input, Func<Match, Task<string>> evaluator)
+        public async Task<string> ReplaceAsync(string input, Func<Match, Task<string>> evaluator)
         {
             Guard.NotNull(regex, nameof(regex));
             Guard.NotNull(input, nameof(input));


### PR DESCRIPTION
## Summary
- update ByteArrayExtensions to use extension block syntax consistent with TagBuilderExtensions
- refactor RegexExtensions into extension block style while preserving existing behaviors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cc50fc7f8832c87b2c336aa76bcf1)