### PR TITLE
Fix search suggestion click issue on Mac/Safari

### DIFF
--- a/src/Smartstore.Web/wwwroot/js/public.search.js
+++ b/src/Smartstore.Web/wwwroot/js/public.search.js
@@ -74,6 +74,13 @@
                     const activeElement = document.activeElement;
                     // Execute code only when focus moves outside of the form container
                     if (!form[0].contains(activeElement)) {
+                        // INFO: On Mac/Safari, clicking a link does not focus it.
+                        // In this case focus moves to body. We avoid closing the drop
+                        // if the mouse is still over the form (result list).
+                        if (activeElement === document.body && form.is(':hover')) {
+                            return;
+                        }
+
                         shrinkBox();
                         closeDrop();
                     }


### PR DESCRIPTION
This PR fixes a bug where users on Mac (specifically Safari) were unable to select search suggestions from the instant search results with a mouse click.

### Problem
In Safari on macOS, clicking a link or a non-focusable element doesn't necessarily move focus to that element. In the case of Smartstore's instant search, clicking a result link caused the search form to lose focus to the document body. The existing `focusout` handler interpreted this as the user clicking away from the search component and immediately closed the results dropdown, preventing the `click` event from being registered by the suggestion link.

### Solution
Modified the `focusout` handler in `src/Smartstore.Web/wwwroot/js/public.search.js` to implement a guard: if focus moves to the `body` element but the mouse is still hovering over the search form (using the jQuery `:hover` selector), the dropdown remains open. This allows the browser to process the click on the result link.

### Verification
- Verified the logic via code review and manual inspection.
- Ran existing `Smartstore.Web.Tests` to ensure no regressions in related backend logic.
- The solution is a standard and safe approach for handling this Safari-specific behavior without impacting other platforms or the "close-on-click-away" functionality.

---
*PR created automatically by Jules for task [5170039500803459290](https://jules.google.com/task/5170039500803459290) started by @Michael-Herzog*